### PR TITLE
fix navbar styling bug

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,3 +19,7 @@
    bottom: 0;
    background-color: rgb(64, 28, 121);
  }
+
+ .navbar {
+   z-index: 100;
+ }


### PR DESCRIPTION
Navbar was hidden behind other elements when expanded in mobile view. Set z-index to ensure navbar is always at the front.