### PR TITLE
Rendering posts as cards

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,8 +1,20 @@
 <% @posts.each do |post| %>
-  <p><%= "#{post.user.email}: #{post.message} #{time_ago_in_words(post.created_at)} ago" %></p>
+  <div class="card" style="width: 18rem;">
+    <img class="card-img-top" src=".../100px180/?text=Image cap" alt="Card image cap">
+    <div class="card-body">
+      <!-- <h5 class="card-title">Card title</h5> -->
+      <p class="card-text"><%="#{post.message}"%></p>
+    </div>
+    <ul class="list-group list-group-flush">
+       <li class="list-group-item"><%= "#{post.user.email}"%></li>
+      <li class="list-group-item"><%="#{time_ago_in_words(post.created_at)} ago"%></li>
+    </ul>
+    <div class="card-body">
+      <a href="#" class="card-link">Like</a>
+      <a href="#" class="card-link">Wall</a>
+    </div>
+  </div>
 <% end %>
-
-
 
 <%= link_to new_post_path do %>
   New post

--- a/helpers.rb
+++ b/helpers.rb
@@ -1,0 +1,7 @@
+def user_signs_up
+    visit "/users/sign_up"
+    fill_in "user_email", with: "jordan@matt.com"
+    fill_in "user_password", with: "123456abc"
+    fill_in "user_password_confirmation", with: "123456abc"
+    click_button "Sign up"
+  end

--- a/spec/features/user_can_sign_up_spec.rb
+++ b/spec/features/user_can_sign_up_spec.rb
@@ -1,11 +1,5 @@
 require 'rails_helper'
-def user_signs_up
-  visit "/users/sign_up"
-  fill_in "user_email", with: "jordan@matt.com"
-  fill_in "user_password", with: "123456abc"
-  fill_in "user_password_confirmation", with: "123456abc"
-  click_button "Sign up"
-end
+require './helpers'
 
 RSpec.feature "Login", type: :feature do
   scenario "The user can sign up successfully" do

--- a/spec/features/user_can_submit_posts_spec.rb
+++ b/spec/features/user_can_submit_posts_spec.rb
@@ -19,12 +19,12 @@ RSpec.feature "Timeline", type: :feature do
   scenario "User email displayed with a post" do
     user_signs_up
     user_makes_a_post
-    expect(page).to have_content("jordan@matt.com: Hello, world!")
+    expect(page).to have_content("Hello, world! jordan@matt.com")
   end
 
-  scenario "Time is displayed with post" do 
+  scenario "Time is displayed with post" do
     user_signs_up
     user_makes_a_post
-    expect(page).to have_content("jordan@matt.com: Hello, world! less than a minute ago")
-  end  
+    expect(page).to have_content("Hello, world! jordan@matt.com less than a minute ago")
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,17 +1,19 @@
 require 'simplecov'
 require 'simplecov-console'
 require 'database_cleaner'
-#allowing travis to run
+
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
  SimpleCov::Formatter::Console,
  SimpleCov::Formatter::HTMLFormatter
 ])
-SimpleCov.start
+SimpleCov.start do
+  add_filter 'helpers.rb'
+end
 DatabaseCleaner[:active_record].strategy = :truncation
 
 RSpec.configure do |config|
-  
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end


### PR DESCRIPTION
- Posts are now rendered as cards using bootstrap
- Tests had to be changed in order to account for the change in rendering the posts, small syntax problem with commas and the order of the post and user email
- Coverage is now 100% as helper method as been moved to a helper file
- Removed a comment in spec helper